### PR TITLE
Update .gitmodules to fix error when cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "gslpp"]
 	path = gslpp
 	url = https://github.com/silvest/gslpp.git
-[submodule "RGESolver/gslpp"]
-	path = gslpp
-	url = https://github.com/silvest/gslpp.git


### PR DESCRIPTION
$$ git clone https://github.com/silvest/RGESolver --recursive Cloning into 'RGESolver'...
remote: Enumerating objects: 1543, done.
remote: Counting objects: 100% (61/61), done.
remote: Compressing objects: 100% (37/37), done.
remote: Total 1543 (delta 40), reused 43 (delta 24), pack-reused 1482 Receiving objects: 100% (1543/1543), 7.16 MiB | 0 bytes/s, done. Resolving deltas: 100% (1114/1114), done.
error: invalid key (newline): submodule.gslpp
RGESolver/gslpp.url
error: invalid key (newline): submodule.gslpp
RGESolver/gslpp.url
No url found for submodule path 'gslpp' in .gitmodules